### PR TITLE
Fix WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Image
-FROM node:20 as build
+FROM node:20 AS build
 WORKDIR /app
 COPY . .
 RUN npm install && npm run build


### PR DESCRIPTION
https://github.com/cypress-io/cypress-docker-images/commit/5322a16ceecb87a232475d4822c4f8fdef48cc96 convert as to AS

# Change Description
ビルド時に警告が出ていたので調べたら，https://github.com/cypress-io/cypress-docker-images/commit/5322a16ceecb87a232475d4822c4f8fdef48cc96
によるとasをASにすれば直るらしい

```
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```